### PR TITLE
Resolve `AttributeError: 'str' object has no attribute 'SerializeToString'`

### DIFF
--- a/fast_sentence_transformers/txtai/pipeline/train/hfonnx.py
+++ b/fast_sentence_transformers/txtai/pipeline/train/hfonnx.py
@@ -36,7 +36,7 @@ class WrapInferenceSession:
     """
 
     def __init__(self, onnx_bytes, sess_options, provider):
-        self.sess = InferenceSession(onnx_bytes.SerializeToString(), sess_options, ["CPUExecutionProvider"])
+        self.sess = InferenceSession(onnx_bytes, sess_options, ["CPUExecutionProvider"])
         self.onnx_bytes = onnx_bytes
         self.sess_options = sess_options
         self.provider = provider
@@ -51,7 +51,7 @@ class WrapInferenceSession:
         self.onnx_bytes = values["onnx_bytes"]
         self.sess_options = values["sess_options"]
         self.provider = values["provider"]
-        self.sess = InferenceSession(self.onnx_bytes.SerializeToString(), self.sess_options, self.provider)
+        self.sess = InferenceSession(self.onnx_bytes, self.sess_options, self.provider)
 
 
 class HFOnnx(Tensors):


### PR DESCRIPTION
Hello!

## Pull Request Overview
* Resolve `AttributeError: 'str' object has no attribute 'SerializeToString'` by removing `SerializeToString()` call.

## Bug details
The bug can be seen in the following places already:
* [fast-sentence-transformers CI runs](https://github.com/Pandora-Intelligence/fast-sentence-transformers/actions/runs/3403676374/jobs/5660365896)
* Running `test.py` for `classy-classification`

The critical section (when I run `test.py` from `classy-classification`):
```python
Traceback (most recent call last):
  File "[sic]/test.py", line 6, in <module>
    classifier = classy_classification.classyClassifier(data=training_data)
  File "[sic]/classy_classification/classifiers/sentence_transformer.py", line 21, in __init__
    self.set_embedding_model()
  File "[sic]/classy_classification/classifiers/sentence_transformer.py", line 37, in set_embedding_model
    embeddings = onnx(self.model, "pooling", "embeddings.onnx", quantize=True)
  File "[sic]/lib/site-packages/fast_sentence_transformers/txtai/pipeline/train/hfonnx.py", line 107, in __call__
    output = self.quantization(output)
  File "[sic]/lib/site-packages/fast_sentence_transformers/txtai/pipeline/train/hfonnx.py", line 139, in quantization
    _ = WrapInferenceSession(output, sess_option, ["CPUExecutionProvider"])
  File "[sic]/lib/site-packages/fast_sentence_transformers/txtai/pipeline/train/hfonnx.py", line 39, in __init__
    self.sess = InferenceSession(onnx_bytes.SerializeToString(), sess_options, ["CPUExecutionProvider"])
AttributeError: 'str' object has no attribute 'SerializeToString'
```

It seems that 16588f3355533bdd8fb6d8dea72b787edc3128cd based on https://github.com/microsoft/onnxruntime/pull/800#issuecomment-844326099 caused this issue. Note: This can **only** be reproduced when the model has to be downloaded/quantized still. If that was already done, then you can't reproduce this behaviour. 

## The fix
The fix speaks for itself here. For us, `onnx_bytes` is either a string or a BytesIO instance, which I reckon should be fine to pass to `InferenceSession`. I'm not very familiar with ONNX at all, so I'm not 100%. It seems to work well (or, better) now.

## Note
I still sometimes get some errors, but I can't tell if they're related:
```
> pytest
==================================================================================== test session starts ====================================================================================
platform win32 -- Python 3.10.1, pytest-7.1.3, pluggy-1.0.0
rootdir: [sic]\fast-sentence-transformers, configfile: pyproject.toml, testpaths: tests
collected 2 items                                                                                                                                                                             

tests\test_configs.py .F                                                                                                                                                               [100%]

========================================================================================= FAILURES ========================================================================================== 
_______________________________________________________________________________________ test_quantize _______________________________________________________________________________________ 

    def test_quantize():
>       from fast_sentence_transformers.examples import test_quantize  # noqa: F401

tests\test_configs.py:6:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
[sic]\lib\site-packages\_pytest\assertion\rewrite.py:168: in exec_module
    exec(co, module.__dict__)
fast_sentence_transformers\examples\test_quantize.py:3: in <module>
    encoder = FastSentenceTransformer("all-MiniLM-L6-v2", quantize=True)
fast_sentence_transformers\FastSentenceTransformer.py:172: in __init__
    self.sbertmodel2onnx()
fast_sentence_transformers\FastSentenceTransformer.py:207: in sbertmodel2onnx
    self.onnx(self.model_path, "default", self.export_model_name, quantize=self.quantize)
fast_sentence_transformers\txtai\pipeline\train\hfonnx.py:107: in __call__
    output = self.quantization(output)
fast_sentence_transformers\txtai\pipeline\train\hfonnx.py:139: in quantization
    _ = WrapInferenceSession(output, sess_option, ["CPUExecutionProvider"])
fast_sentence_transformers\txtai\pipeline\train\hfonnx.py:39: in __init__
    self.sess = InferenceSession(onnx_bytes, sess_options, ["CPUExecutionProvider"])
[sic]\lib\site-packages\onnxruntime\capi\onnxruntime_inference_collection.py:347: in __init__      
    self._create_inference_session(providers, provider_options, disabled_optimizers)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <onnxruntime.capi.onnxruntime_inference_collection.InferenceSession object at 0x000001E920BFBE80>, providers = ['CPUExecutionProvider'], provider_options = [{}]
disabled_optimizers = set()

    def _create_inference_session(self, providers, provider_options, disabled_optimizers=None):
        available_providers = C.get_available_providers()

        # Tensorrt can fall back to CUDA. All others fall back to CPU.
        if "TensorrtExecutionProvider" in available_providers:
            self._fallback_providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
        elif "MIGraphXExecutionProvider" in available_providers:
            self._fallback_providers = ["ROCMExecutionProvider", "CPUExecutionProvider"]
        else:
            self._fallback_providers = ["CPUExecutionProvider"]

        # validate providers and provider_options before other initialization
        providers, provider_options = check_and_normalize_provider_args(
            providers, provider_options, available_providers
        )
        if providers == [] and len(available_providers) > 1:
            self.disable_fallback()
            raise ValueError(
                "This ORT build has {} enabled. ".format(available_providers)
                + "Since ORT 1.9, you are required to explicitly set "
                + "the providers parameter when instantiating InferenceSession. For example, "
                "onnxruntime.InferenceSession(..., providers={}, ...)".format(available_providers)
            )

        session_options = self._sess_options if self._sess_options else C.get_default_session_options()
        if self._model_path:
            sess = C.InferenceSession(session_options, self._model_path, True, self._read_config_from_model)
        else:
            sess = C.InferenceSession(session_options, self._model_bytes, False, self._read_config_from_model)

        if disabled_optimizers is None:
        elif not isinstance(disabled_optimizers, set):
            # convert to set. assumes iterable
            disabled_optimizers = set(disabled_optimizers)

        # initialize the C++ InferenceSession
>       sess.initialize_session(providers, provider_options, disabled_optimizers)
E       onnxruntime.capi.onnxruntime_pybind11_state.InvalidProtobuf: [ONNXRuntimeError] : 7 : INVALID_PROTOBUF : Protobuf serialization failed.

[sic]\lib\site-packages\onnxruntime\capi\onnxruntime_inference_collection.py:395: InvalidProtobuf  
------------------------------------------------------------------------------------- Captured log call ------------------------------------------------------------------------------------- 
WARNING  fast_sentence_transformers.FastSentenceTransformer:FastSentenceTransformer.py:160 Using CPU. Try installing 'onnxruntime-gpu'.
===================================================================================== warnings summary ======================================================================================
```
And on another run:
```
Traceback (most recent call last):
  File "[sic]\demo.py", line 5, in <module>
    encoder = SentenceTransformer("all-MiniLM-L6-v2", device="cpu", quantize=True)
  File "[sic]\fast_sentence_transformers\FastSentenceTransformer.py", line 172, in __init__
    self.sbertmodel2onnx()
  File "[sic]\fast_sentence_transformers\FastSentenceTransformer.py", line 207, in sbertmodel2onnx
    self.onnx(self.model_path, "default", self.export_model_name, quantize=self.quantize)
  File "[sic]\fast_sentence_transformers\txtai\pipeline\train\hfonnx.py", line 107, in __call__
    output = self.quantization(output)
  File "[sic]\fast_sentence_transformers\txtai\pipeline\train\hfonnx.py", line 142, in quantization
    quantize_dynamic(output, output, optimize_model=False)
  File "[sic]\lib\site-packages\onnxruntime\quantization\quantize.py", line 250, in quantize_dynamic
    quantizer = ONNXQuantizer(
  File "[sic]\lib\site-packages\onnxruntime\quantization\onnx_quantizer.py", line 125, in __init__ 
    self.opset_version = self.check_opset_version()
  File "[sic]\lib\site-packages\onnxruntime\quantization\onnx_quantizer.py", line 218, in check_opset_version
    raise ValueError("Failed to find proper ai.onnx domain")
ValueError: Failed to find proper ai.onnx domain
```

But I can't consistently reproduce either of those.

### After this PR
Running this script with or without "all-MiniLM-L6-v2" being cached both work correctly now:
```
from fast_sentence_transformers import FastSentenceTransformer as SentenceTransformer

encoder = SentenceTransformer("all-MiniLM-L6-v2", device="cpu", quantize=True)

encoded = encoder.encode("Hello hello, hey, hello hello")
print(encoded)
```

(Although I do get these warnings when the model hasn't been cached yet:)
```
Ignore MatMul due to non constant B: /[MatMul_107]
Ignore MatMul due to non constant B: /[MatMul_112]
Ignore MatMul due to non constant B: /[MatMul_201]
Ignore MatMul due to non constant B: /[MatMul_206]
Ignore MatMul due to non constant B: /[MatMul_295]
Ignore MatMul due to non constant B: /[MatMul_300]
Ignore MatMul due to non constant B: /[MatMul_389]
Ignore MatMul due to non constant B: /[MatMul_394]
Ignore MatMul due to non constant B: /[MatMul_483]
Ignore MatMul due to non constant B: /[MatMul_488]
Ignore MatMul due to non constant B: /[MatMul_577]
Ignore MatMul due to non constant B: /[MatMul_582]
```

Note also that I did not use `onnxruntime-gpu` as I had some issues there.

In short, this PR might not be a silver bullet, and you can also consider this as an issue to let you know that there's a critical bug.

- Tom Aarsen