### PR TITLE
Fixed dimension of normalized embeddings

### DIFF
--- a/fast_sentence_transformers/FastSentenceTransformer.py
+++ b/fast_sentence_transformers/FastSentenceTransformer.py
@@ -289,7 +289,8 @@ class FastSentenceTransformer(object):
                 embeddings = embeddings.cpu().detach().numpy()
 
             if normalize_embeddings:
-                embeddings = np.linalg.norm(embeddings, ord=2, axis=1, keepdims=False)
+                norms = np.linalg.norm(embeddings, ord=2, axis=1, keepdims=True)
+                embeddings = embeddings/np.where(norms<1e-12, 1e-12, norms)
 
             all_embeddings.extend(embeddings)
 


### PR DESCRIPTION
# Pull Request Overview
Fixes the issue described [here](https://github.com/Pandora-Intelligence/fast-sentence-transformers/issues/3), where using `normalize_embeddings=True` returned an incorrect result. 

## Brief
```python
embeddings = np.linalg.norm(embeddings, ord=2, axis=1, keepdims=False)
```
was changed to 
```python
norms = np.linalg.norm(embeddings, ord=2, axis=1, keepdims=True)
embeddings = embeddings/np.where(norms<1e-12, 1e-12, norms)
```
 so that the output is same as the original [SentenceTransformer.py](https://github.com/UKPLab/sentence-transformers/blob/master/sentence_transformers/SentenceTransformer.py).

## Minimum reproducible example
```python
from fast_sentence_transformers import FastSentenceTransformer as SentenceTransformer
encoder = SentenceTransformer("all-MiniLM-L6-v2", device="cpu", quantize=False)
print(encoder.encode("Hello hello, hey, hello hello", normalize_embeddings=True).shape)
```
output before this PR
```
()
```
output after this PR
```
(384,)
```